### PR TITLE
Added more resources about cpython development

### DIFF
--- a/cpython/index.md
+++ b/cpython/index.md
@@ -2,3 +2,6 @@
 
 - [2015 Unofficial PyLadies Guide to Contributing to CPython](http://jazzy-groove-guide-to-cpython-contribution.readthedocs.io/en/latest/) and accompanying [PyCon talk by @willingc](https://www.youtube.com/watch?v=szeo1XgmuEk) and [slide deck](http://www.slideshare.net/willingc/finding-your-groove). 
 - [Git and GitHub information on creating and applying a patch](gitcpython.md)
+- [CPython Dev Guide](http://cpython-devguide.readthedocs.io/en/latest/) Comprehensive guide for contributing to core python. 
+- [Being a Core Developer in Python](https://youtu.be/voXVTjwnn-U?list=PL85KuAjbN_gtGn4v1ELSWJlTFZF_5Ciog) Keynote by Raymond Hettinger for PyBay 2016
+- [Python Core Mentorship Mailing List](https://mail.python.org/mailman/listinfo/core-mentorship) 


### PR DESCRIPTION
Added the following resources
- link to cpython dev guide
- Raymond Hettinger's PyBay keynote
- core mentorship mailing list
